### PR TITLE
added try / except to write_records 

### DIFF
--- a/healthkit_to_sqlite/utils.py
+++ b/healthkit_to_sqlite/utils.py
@@ -1,4 +1,5 @@
 from xml.etree import ElementTree as ET
+import sqlite3
 
 
 def find_all_tags(fp, tags, progress_callback=None):
@@ -139,9 +140,12 @@ def write_records(records, db):
         records_by_type.setdefault(table, []).append(record)
     # Bulk inserts for each one
     for table, records_for_table in records_by_type.items():
-        db[table].insert_all(
-            records_for_table,
-            alter=True,
-            column_order=["startDate", "endDate", "value", "unit"],
-            batch_size=50,
-        )
+        try:
+            db[table].insert_all(
+                records_for_table,
+                alter=True,
+                column_order=["startDate", "endDate", "value", "unit"],
+                batch_size=50,
+            )
+        except (sqlite3.OperationalError, sqlite3.IntegrityError):
+            pass


### PR DESCRIPTION
to keep the data write from failing if it came across an error during processing. In particular when trying to convert my HealthKit zip file (and that of my wife's) it would consistently error out with the following:

```
db.py 1709 insert_chunk
result = self.db.execute(query, params)

db.py 226 execute
return self.conn.execute(sql, parameters)

sqlite3.OperationalError:
too many SQL variables

---------------------------------------------------------------------------------------------------------------------------------------------------------------------
db.py 1709 insert_chunk
result = self.db.execute(query, params)

db.py 226 execute
return self.conn.execute(sql, parameters)

sqlite3.OperationalError:
too many SQL variables

---------------------------------------------------------------------------------------------------------------------------------------------------------------------
db.py 1709 insert_chunk
result = self.db.execute(query, params)

db.py 226 execute
return self.conn.execute(sql, parameters)

sqlite3.OperationalError:
table rBodyMass has no column named metadata_HKWasUserEntered

---------------------------------------------------------------------------------------------------------------------------------------------------------------------
healthkit-to-sqlite 8 <module>
sys.exit(cli())

core.py 829 __call__
return self.main(*args, **kwargs)

core.py 782 main
rv = self.invoke(ctx)

core.py 1066 invoke
return ctx.invoke(self.callback, **ctx.params)

core.py 610 invoke
return callback(*args, **kwargs)

cli.py 57 cli
convert_xml_to_sqlite(fp, db, progress_callback=bar.update, zipfile=zf)

utils.py 42 convert_xml_to_sqlite
write_records(records, db)

utils.py 143 write_records
db[table].insert_all(

db.py 1899 insert_all
self.insert_chunk(

db.py 1720 insert_chunk
self.insert_chunk(

db.py 1720 insert_chunk
self.insert_chunk(

db.py 1714 insert_chunk
result = self.db.execute(query, params)

db.py 226 execute
return self.conn.execute(sql, parameters)

sqlite3.OperationalError:
table rBodyMass has no column named metadata_HKWasUserEntered
```

Adding the try / except in the `write_records` seems to fix that issue. 