### PR TITLE
Include workout statistics

### DIFF
--- a/healthkit_to_sqlite/utils.py
+++ b/healthkit_to_sqlite/utils.py
@@ -54,6 +54,7 @@ def workout_to_db(workout, db, zipfile=None):
         record["metadata_" + el.attrib["key"]] = el.attrib["value"]
     # Dump any WorkoutEvent in a nested list for the moment
     record["workout_events"] = [el.attrib for el in workout.findall("WorkoutEvent")]
+    record["workout_statistics"] = [el.attrib for el in workout.findall("WorkoutStatistics")]
     pk = db["workouts"].insert(record, alter=True, hash_id="id").last_pk
     # Handle embedded WorkoutRoute/Location points
     points = [


### PR DESCRIPTION
Not sure when this changed (iOS 16 maybe?), but the `WorkoutStatistics` now has a whole bunch of information about workouts, e.g. for runs it contains the distance (as a `<WorkoutStatistics type="HKQuantityTypeIdentifierDistanceWalkingRunning ...>` element).

Adding it as another column at leat allows me to pull these out (using SQLite's JSON support).
I'm running with this patch on my own data now.